### PR TITLE
Add missing __program_root_section symbol

### DIFF
--- a/calypsi/hello/ram-startup.s
+++ b/calypsi/hello/ram-startup.s
@@ -38,6 +38,8 @@
               .section code, noreorder
 #endif
               .pubweak __program_start
+              .pubweak __program_root_section
+__program_root_section:
 __program_start:
               clc
               xce                   ; native 16-bit mode


### PR DESCRIPTION
This symbol marks the root section and need to be present in a C-startup module.